### PR TITLE
Added jackson libraries with a custom failing test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 
 # Build
 build/
+*.iml
+\.idea/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,15 @@ env:
   - TEST_DIR=joda-time-joda-time
   - TEST_DIR=org.joda-joda-primitives
   - TEST_DIR=org.apache.commons-commons-lang3
+  - TEST_DIR=com.fasterxml.jackson.core
 
 # Uncomment to add a library that should fail to build, along with documentation on why.
-# matrix:
-#   allow_failures:
-#     # Blocked on (github issue url)
-#     - env: TEST_DIR=libraryBuilds/com.example-library
+matrix:
+  allow_failures:
+      # Blocked on (github issue url)
+#     - env: TEST_DIR=com.example-library
+      # Blocked on: update of j2objc with this issue fixed: https://github.com/google/j2objc/issues/639
+    - env: TEST_DIR=com.fasterxml.jackson.core
 
 branches:
   only:

--- a/libraryBuilds/com.fasterxml.jackson.core/build.gradle
+++ b/libraryBuilds/com.fasterxml.jackson.core/build.gradle
@@ -1,0 +1,1 @@
+../common/build.gradle

--- a/libraryBuilds/com.fasterxml.jackson.core/com.fasterxml.jackson.core-jackson-annotations/build.gradle
+++ b/libraryBuilds/com.fasterxml.jackson.core/com.fasterxml.jackson.core-jackson-annotations/build.gradle
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2015 the authors of j2objc-common-libs-e2e-test
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
+dependencies {
+    compile project(':com.fasterxml.jackson.core-jackson-core')
+    j2objcTranslation 'com.fasterxml.jackson.core:jackson-annotations:2.5.3:sources'
+}
+
+j2objcConfig {
+    autoConfigureDeps true
+
+    // Almost always there are no tests provided in an external source jar.
+    testMinExpectedTests 0
+    finalConfigure()
+}

--- a/libraryBuilds/com.fasterxml.jackson.core/com.fasterxml.jackson.core-jackson-core/build.gradle
+++ b/libraryBuilds/com.fasterxml.jackson.core/com.fasterxml.jackson.core-jackson-core/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2015 the authors of j2objc-common-libs-e2e-test
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
+dependencies {
+    j2objcTranslation 'com.fasterxml.jackson.core:jackson-core:2.5.3:sources'
+}
+
+j2objcConfig {
+    translateArgs '--segmented-headers' // import loops
+
+    testMinExpectedTests 0
+    finalConfigure()
+}

--- a/libraryBuilds/com.fasterxml.jackson.core/com.fasterxml.jackson.core-jackson-databind/build.gradle
+++ b/libraryBuilds/com.fasterxml.jackson.core/com.fasterxml.jackson.core-jackson-databind/build.gradle
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2015 the authors of j2objc-common-libs-e2e-test
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
+dependencies {
+    compile project(':com.fasterxml.jackson.core-jackson-core')
+    compile project(':com.fasterxml.jackson.core-jackson-annotations')
+    j2objcTranslation 'com.fasterxml.jackson.core:jackson-databind:2.5.3:sources'
+    testCompile 'junit:junit:4.11'
+}
+
+j2objcConfig {
+
+    translateArgs '--segmented-headers'
+    translateArgs '--extract-unsequenced'
+    
+    autoConfigureDeps true
+
+    translatePattern {
+        exclude '**/fasterxml/jackson/databind/ext/DOMSerializer.java'
+    }
+    finalConfigure()
+}

--- a/libraryBuilds/com.fasterxml.jackson.core/com.fasterxml.jackson.core-jackson-databind/src/test/java/com/github/j2objccontrib/j2objcgradle/CoreJacksonDataBindMarshallingTest.java
+++ b/libraryBuilds/com.fasterxml.jackson.core/com.fasterxml.jackson.core-jackson-databind/src/test/java/com/github/j2objccontrib/j2objcgradle/CoreJacksonDataBindMarshallingTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2015 the authors of j2objc-common-libs-e2e-test
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.j2objccontrib.j2objcgradle;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CoreJacksonDataBindMarshallingTest {
+
+    private static String jsonValue = "{\n" +
+            "  \"addressList\": [\n" +
+            "    {\n" +
+            "      \"zipcode\": 12345,\n" +
+            "      \"street\": \"Stenhammer Drive\"\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"zipcode\": 7986,\n" +
+            "      \"street\": \"Market Street\"\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"singleAddress\": {\n" +
+            "    \"zipcode\": 7986,\n" +
+            "    \"street\": \"Market Street\"\n" +
+            "  }\n" +
+            "}" ;
+
+    @Test
+    public void testMarshalling() throws IOException {
+        Address homeAddress = new Address(12345, "Stenhammer Drive");
+        Address workAddress = new Address(7986, "Market Street");
+        ArrayList<Address> addressList = new ArrayList<>();
+        addressList.add(homeAddress);
+        addressList.add(workAddress);
+        Person person = new Person(addressList);
+        person.setSingleAddress(workAddress);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String value = objectMapper.writeValueAsString(person);
+
+        JsonNode expected = objectMapper.readTree(jsonValue);
+        JsonNode actual = objectMapper.readTree(value);
+        Assert.assertEquals(expected, actual);
+
+    }
+
+    @Test
+    public void testDemarshallingWithEmbeddedObject() throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        Person personValue = objectMapper.readValue(jsonValue, Person.class);
+        Assert.assertTrue(personValue.getSingleAddress() instanceof Address);
+        Assert.assertEquals(7986, personValue.singleAddress.zipcode);
+        Assert.assertEquals("Market Street", personValue.singleAddress.street);
+    }
+
+    // This test is expected to fail until j2objc is updated to a version where
+    // this issue is fixed: https://github.com/google/j2objc/issues/639
+    @Test
+    public void testDemarshallingListField() throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        Person personValue = objectMapper.readValue(jsonValue, Person.class);
+
+        List<Address> addresses = personValue.getAddressList();
+        Assert.assertEquals(2, addresses.size());
+        Address firstAddress = addresses.get(0);
+        Assert.assertTrue(firstAddress instanceof Address);
+
+        Assert.assertEquals(12345, firstAddress.zipcode);
+        Assert.assertEquals("Stenhammer Drive", firstAddress.street);
+    }
+
+    public static class Person {
+
+        private ArrayList<Address> addressList;
+        private Address singleAddress;
+
+        public Person(ArrayList<Address> addressList) {
+            this.addressList = addressList;
+        }
+
+        Person() {
+        }
+
+        public List<Address> getAddressList() {
+            return addressList;
+        }
+
+        public void setAddressList(ArrayList<Address> addressList) {
+            this.addressList = addressList;
+        }
+
+        public Address getSingleAddress() {
+            return singleAddress;
+        }
+
+        public void setSingleAddress(Address singleAddress) {
+            this.singleAddress = singleAddress;
+        }
+    }
+
+    public static class Address {
+
+        private int zipcode;
+        private String street;
+
+        Address() {
+        }
+
+        public Address(int zipcode,
+                       String street) {
+            this.zipcode = zipcode;
+            this.street = street;
+        }
+
+        public int getZipcode() {
+            return zipcode;
+        }
+
+        public String getStreet() {
+            return street;
+        }
+
+        public void setZipcode(int zipcode) {
+            this.zipcode = zipcode;
+        }
+
+        public void setStreet(String street) {
+            this.street = street;
+        }
+    }
+} 

--- a/libraryBuilds/com.fasterxml.jackson.core/gradlew
+++ b/libraryBuilds/com.fasterxml.jackson.core/gradlew
@@ -1,0 +1,1 @@
+../../j2objc-gradle/gradlew

--- a/libraryBuilds/com.fasterxml.jackson.core/local.properties
+++ b/libraryBuilds/com.fasterxml.jackson.core/local.properties
@@ -1,0 +1,1 @@
+../common/local.properties

--- a/libraryBuilds/com.fasterxml.jackson.core/settings.gradle
+++ b/libraryBuilds/com.fasterxml.jackson.core/settings.gradle
@@ -1,0 +1,1 @@
+include ':com.fasterxml.jackson.core-jackson-core',':com.fasterxml.jackson.core-jackson-annotations',':com.fasterxml.jackson.core-jackson-databind'

--- a/libraryBuilds/common/build.gradle
+++ b/libraryBuilds/common/build.gradle
@@ -36,4 +36,12 @@ subprojects {
     repositories {
         jcenter()
     }
+
+    test {
+        testLogging {
+            // Provide full exception info on failure, instead
+            // of just pointing to an HTML file.
+            exceptionFormat 'full'
+        }
+    }
 }

--- a/run-all.sh
+++ b/run-all.sh
@@ -24,3 +24,4 @@ set -euv
 ./run-test.sh libraryBuilds/joda-time-joda-time
 ./run-test.sh libraryBuilds/org.joda-joda-primitives
 ./run-test.sh libraryBuilds/org.apache.commons-commons-lang3
+./run-test.sh libraryBuilds/com.fasterxml.jackson.core


### PR DESCRIPTION
added jackson libraries with a failing test
test shows that jackson cannot demarshall embedded lists correctly
